### PR TITLE
Changing the master-slave phrasing

### DIFF
--- a/config.example.py
+++ b/config.example.py
@@ -223,7 +223,7 @@ ITEM_LIMITS = {
     1:    0,  # Poké Ball
     2:    0,  # Great Ball
     3:    5,  # Ultra Ball
-    4:    10,  # Master Ball
+    4:    10,  # Main Ball
     101:   0,  # Potion
     102:   0,  # Super Potion
     103:   0,  # Hyper Potion

--- a/monocle/worker.py
+++ b/monocle/worker.py
@@ -730,7 +730,7 @@ class Worker:
 
     async def account_promotion(self):
         if self.player_level and self.player_level >= 30:
-            self.log.warning('Congratulations {} has reached Lv.30. Moving it out of low-level slave pool', self.username)
+            self.log.warning('Congratulations {} has reached Lv.30. Moving it out of low-level subordinate pool', self.username)
             await sleep(1, loop=LOOP)
             await self.remove_account(flag='level30')
 
@@ -1769,7 +1769,7 @@ class Worker:
             log_message = "Removing {} due to temp disabled. Level - {}".format(self.username, self.player_level)
         elif flag == 'level30':
             self.account['graduated'] = True
-            log_message = "Removing {} from slave pool due to graduation to Lv.30. Level - {}".format(self.username, self.player_level)
+            log_message = "Removing {} from subordinate pool due to graduation to Lv.30. Level - {}".format(self.username, self.player_level)
             send_webhook = False
         elif flag == 'level1':
             self.account['demoted'] = True


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.